### PR TITLE
Fix(ang_vel): switch motors in angular velocity calculation to satisf…

### DIFF
--- a/include/protocol_pro.hpp
+++ b/include/protocol_pro.hpp
@@ -95,7 +95,7 @@ class RoverRobotics::ProProtocolObject
   const int RECEIVE_MSG_LEN_ = 5;
   const double wheel2wheelDistance = 0.365; // center distance between the wheels
   const double odom_angular_coef_ = 1/wheel2wheelDistance;
-  const double odom_traction_factor_ = 0.9877; // Default for 2WD is 0.9877, 4WD is 0.610, flipper is 0.98
+  const double odom_traction_factor_ = 0.610; // Default for 2WD is 0.9877, 4WD is 0.610, flipper is 0.98
   const double CONTROL_LOOP_TIMEOUT_MS_ = 200;
   std::unique_ptr<CommBase> comm_base_;
   std::string comm_type_;

--- a/include/protocol_pro.hpp
+++ b/include/protocol_pro.hpp
@@ -93,8 +93,9 @@ class RoverRobotics::ProProtocolObject
   const int requestbyte_ = 10;
   const int termios_baud_code_ = 4097;  // THIS = baudrate of 57600
   const int RECEIVE_MSG_LEN_ = 5;
-  const double odom_angular_coef_ = 2.3;
-  const double odom_traction_factor_ = 0.7;
+  const double wheel2wheelDistance = 0.365; // center distance between the wheels
+  const double odom_angular_coef_ = 1/wheel2wheelDistance;
+  const double odom_traction_factor_ = 0.9877; // Default for 2WD is 0.9877, 4WD is 0.610, flipper is 0.98
   const double CONTROL_LOOP_TIMEOUT_MS_ = 200;
   std::unique_ptr<CommBase> comm_base_;
   std::string comm_type_;

--- a/src/protocol_pro.cpp
+++ b/src/protocol_pro.cpp
@@ -115,8 +115,6 @@ void ProProtocolObject::motors_control_loop(int sleeptime) {
       }
     }
     // !Applying some Skid-steer math
-    // double motor1_vel = linear_vel - 0.5 * angular_vel;
-    // double motor2_vel = linear_vel + 0.5 * angular_vel;
     double motor1_vel = linear_vel - 0.5 * wheel2wheelDistance * angular_vel;
     double motor2_vel = linear_vel + 0.5 * wheel2wheelDistance * angular_vel;
     if (motor1_vel == 0) motor1_control_.reset();

--- a/src/protocol_pro.cpp
+++ b/src/protocol_pro.cpp
@@ -307,8 +307,8 @@ void ProProtocolObject::unpack_comm_response(std::vector<uint8_t> robotmsg) {
                    robotstatus_.motor2_rpm * 2 / MOTOR_RPM_TO_MPS_RATIO_);
 
         robotstatus_.angular_vel =
-            ((robotstatus_.motor1_rpm * 2 / MOTOR_RPM_TO_MPS_RATIO_) -
-             (robotstatus_.motor2_rpm * 2 / MOTOR_RPM_TO_MPS_RATIO_)) *
+            ((robotstatus_.motor2_rpm * 2 / MOTOR_RPM_TO_MPS_RATIO_) -
+             (robotstatus_.motor1_rpm * 2 / MOTOR_RPM_TO_MPS_RATIO_)) *
             odom_angular_coef_ * odom_traction_factor_;
       } else {
         robotstatus_.linear_vel =
@@ -316,8 +316,8 @@ void ProProtocolObject::unpack_comm_response(std::vector<uint8_t> robotmsg) {
                    robotstatus_.motor2_rpm / MOTOR_RPM_TO_MPS_RATIO_);
 
         robotstatus_.angular_vel =
-            ((robotstatus_.motor1_rpm / MOTOR_RPM_TO_MPS_RATIO_) -
-             (robotstatus_.motor2_rpm / MOTOR_RPM_TO_MPS_RATIO_)) *
+            ((robotstatus_.motor2_rpm / MOTOR_RPM_TO_MPS_RATIO_) -
+             (robotstatus_.motor1_rpm / MOTOR_RPM_TO_MPS_RATIO_)) *
             odom_angular_coef_ * odom_traction_factor_;
       }
 

--- a/src/protocol_pro.cpp
+++ b/src/protocol_pro.cpp
@@ -115,8 +115,10 @@ void ProProtocolObject::motors_control_loop(int sleeptime) {
       }
     }
     // !Applying some Skid-steer math
-    double motor1_vel = linear_vel - 0.5 * angular_vel;
-    double motor2_vel = linear_vel + 0.5 * angular_vel;
+    // double motor1_vel = linear_vel - 0.5 * angular_vel;
+    // double motor2_vel = linear_vel + 0.5 * angular_vel;
+    double motor1_vel = linear_vel - 0.5 * wheel2wheelDistance * angular_vel;
+    double motor2_vel = linear_vel + 0.5 * wheel2wheelDistance * angular_vel;
     if (motor1_vel == 0) motor1_control_.reset();
     if (motor2_vel == 0) motor2_control_.reset();
     std::cerr << "Firmware V: " << firmware;


### PR DESCRIPTION
…y right hand rule for positive yaw velocity

NOTE: this assumes that a right-handed coordinate frame is/should be used, which is in line with [ros rep 103](https://www.ros.org/reps/rep-0103.html#axis-orientation), if this is not desired/the case this PR is incorrect!

As per the right hand rule the yaw direction should be positive when turning from the positive x-axis to the positive y-axis. Given that driving forward is found and verified to be equal to the positive x-direction, which corresponds to [ros rep 103](https://www.ros.org/reps/rep-0103.html#axis-orientation), the positive y-direction, according to the right-handed coordinate frame, should be to the left of the robot. Therefore turning around the left wheel of the robot should yield a positive yaw. 

From lines 131-136 of this [file](https://github.com/whoutman/librover/blob/release/src/protocol_pro.cpp#L131) it is assumed/deduced that motor 1 corresponds to the left wheel and motor 2 to the right wheel. If we then take as an example an instance where the robot is turning around the left wheel, a.k.a. motor1_rpm < motor2_rpm, this should lead to a positive yaw. In the current status this would lead to a negative yaw. 

These findings are supported by the change in the yaw sign between the cmd_vel topic inputted in and the odom topic outputted by the roverrobotics_driver node.

WARNING: this is an PR changes the api and therefore also affects the output of the roverrobotics_driver node. However I believe that this is the correct way forward!