### PR TITLE
Fix(angular_velocity): change odom_angular_coef and odom_traction_factor

### DIFF
--- a/include/protocol_pro.hpp
+++ b/include/protocol_pro.hpp
@@ -93,8 +93,8 @@ class RoverRobotics::ProProtocolObject
   const int requestbyte_ = 10;
   const int termios_baud_code_ = 4097;  // THIS = baudrate of 57600
   const int RECEIVE_MSG_LEN_ = 5;
-  const double odom_angular_coef_ = 2.3;
-  const double odom_traction_factor_ = 0.7;
+  const double odom_angular_coef_ = 2.74;      // Note: this value is 1/l with l, center distance between the wheels, being 0.365
+  const double odom_traction_factor_ = 0.9877; // Default for 2WD is 0.9877, 4WD is 0.610, flipper is 0.98
   const double CONTROL_LOOP_TIMEOUT_MS_ = 200;
   std::unique_ptr<CommBase> comm_base_;
   std::string comm_type_;


### PR DESCRIPTION
The calculation for the angular_velocity is as follows:
`        robotstatus_.angular_vel =
            ((robotstatus_.motor1_rpm / MOTOR_RPM_TO_MPS_RATIO_) -
             (robotstatus_.motor2_rpm / MOTOR_RPM_TO_MPS_RATIO_)) *
            odom_angular_coef_ * odom_traction_factor_;`

The formula for calculating the angular velocity is as follows: 

> w = (v_r - v_l) / l
With v_r being the speed of the right wheel, v_l being the speed (m/s) of the left wheel en l being the distance between the center of the two wheels (m).

Seeing that the "odom_traction_factor" is mentioned [here](http://wiki.ros.org/rr_openrover_driver) as a scaling factor due to wheel slippage it seems to me that the "odom_angular_coef_" should be equal to 1/l. 
Given this assumption the current value of 2.3 translates to an l value of roughly 43 centimeters. This value does represent the width of the robot at the actuated wheels, but as mentioned above the l value should describe the distance between the CENTERs of both wheels, which was found to be 36.5 cm, resulting in a value of 2.74

On top of this the odom_traction_factor is changed according to the [old documentation](http://wiki.ros.org/rr_openrover_driver), in this case for a 2WD robot, but I think it would be wise to somehow make an if/else distinction between robot types such that this value can be set properly automatically.

These changes were prompted by a mismatch between reality and what was found in the odom topic. After these changes were applied reality and the odom topic matched quite well, as they should.