### PR TITLE
Update pro motor command calculation to account for traction factor

### DIFF
--- a/src/protocol_pro.cpp
+++ b/src/protocol_pro.cpp
@@ -115,8 +115,8 @@ void ProProtocolObject::motors_control_loop(int sleeptime) {
       }
     }
     // !Applying some Skid-steer math
-    double motor1_vel = linear_vel - 0.5 * wheel2wheelDistance * angular_vel;
-    double motor2_vel = linear_vel + 0.5 * wheel2wheelDistance * angular_vel;
+    double motor1_vel = linear_vel - 0.5 * wheel2wheelDistance * angular_vel / odom_traction_factor_;
+    double motor2_vel = linear_vel + 0.5 * wheel2wheelDistance * angular_vel / odom_traction_factor_;
     if (motor1_vel == 0) motor1_control_.reset();
     if (motor2_vel == 0) motor2_control_.reset();
     if (firmware == OVF_FIXED_FIRM_VER_) {  // check firmware version


### PR DESCRIPTION
I was seeing a steady state offset in the angular velocity actual versus the commanded on a rover pro. I noticed that when calculating angular velocity from the encoders it accounts for the traction factor but does not when calculating the motor commands. This is especially noticeable with the 4WD traction factor. This PR adds the traction factor into the motor command. Testing shows it meeting the set-point correctly.